### PR TITLE
[CON-122] Fixing product image preview in zonos modal

### DIFF
--- a/src/Services/DataMapperService.php
+++ b/src/Services/DataMapperService.php
@@ -79,7 +79,7 @@ class DataMapperService
 
       $result = match ($value) {
         'quantity' => $this->mapQuantity($result, $key, $cart_item),
-        'image_id' => $this->mapImage($result, $key, (int)$productData[$value] ?? null),
+        'image_id' => $this->mapImage($result, $key, (int)$product->get_image_id() ?? null),
         'length', 'width', 'height' => $this->mapDimension($result, $value, (float)$productData[$value] ?? null),
         'weight' => $this->mapWeight($result, (float)$productData[$value] ?? null),
         default => $this->mapByValue($key, $value, $result, $product, $productData, $cart_item),


### PR DESCRIPTION
The image is not published in the function `$product->get_data()` so we need to access directly the image