### PR TITLE
Fix: use cart item product object for accurate third-party pricing

### DIFF
--- a/src/Services/WordPressService.php
+++ b/src/Services/WordPressService.php
@@ -73,9 +73,13 @@ class WordPressService extends AbstractZonosService
 
     foreach ($cart->get_cart() as $cartItem) {
       try {
-        $product = wc_get_product($cartItem['product_id']);
-        if (!empty($cartItem['variation_id'])) {
-          $product = wc_get_product($cartItem['variation_id']);
+        // Use the cart item's product object ($cartItem['data']) which reflects
+        // prices modified by third-party plugins (e.g., YITH Dynamic Pricing,
+        // B2B price rules) via woocommerce_before_calculate_totals hooks.
+        // Falling back to wc_get_product() only if cart data is unavailable.
+        $product = $cartItem['data'] ?? null;
+        if (!$product instanceof \WC_Product) {
+          $product = wc_get_product(!empty($cartItem['variation_id']) ? $cartItem['variation_id'] : $cartItem['product_id']);
         }
         $mappedProduct = $this->dataMapperService->mapProductData($cartItem, $product);
 


### PR DESCRIPTION
Use $cartItem['data'] instead of wc_get_product() when exporting cart items. This picks up price modifications from third-party plugins (e.g., YITH Dynamic Pricing, B2B price rules) that adjust prices via woocommerce_before_calculate_totals hooks. Falls back to wc_get_product() if cart data is unavailable.
<img width="832" height="1495" alt="Screenshot 2026-03-24 at 10 12 11" src="https://github.com/user-attachments/assets/9b30a89e-5920-4244-a45b-271faea1f2fd" />


I'm not super familiar with Woo, Claude helped me whip up this PR. The screenshot shows the task we received. Please let me know if you all have any questions or concerns! I also did not test this locally.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how product data is sourced during cart export, which can affect pricing/line items sent to Zonos and downstream totals. Low code churn, but it touches checkout/cart calculation behavior and depends on WooCommerce cart item structure.
> 
> **Overview**
> Ensures `exportOrder()` uses the cart item’s existing product object (`$cartItem['data']`) when mapping items, so **third-party pricing adjustments applied to the cart** are reflected in the data sent to Zonos.
> 
> Adds a guarded fallback to `wc_get_product()` (variation ID preferred) when cart data is missing or not a `WC_Product`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 51e4731a8c005991776b55331ec16cfa06f80609. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->