### PR TITLE
Add Datadog service definition for Software Catalog

### DIFF
--- a/.github/service.datadog.yaml
+++ b/.github/service.datadog.yaml
@@ -1,0 +1,25 @@
+apiVersion: v3
+kind: service
+metadata:
+  name: zonos-php-sdk
+  owner: team-08-plugins
+  description: >-
+    PHP SDK for integrating with Zonos services, providing access
+    to the Zonos GraphQL API.
+  tags:
+    - language:php
+    - cloud_provider:aws
+  contacts:
+    - name: Team 08 - Plugins
+      type: slack
+      contact: https://zonos.slack.com/archives/C09NR9ZGQDR
+  links:
+    - name: Source Code
+      type: repo
+      url: https://github.com/Zonos/zonos-php-sdk
+      provider: github
+spec:
+  lifecycle: production
+  tier: "silver"
+  languages:
+    - php


### PR DESCRIPTION
## Summary
- Adds `.github/service.datadog.yaml` to register this service in Datadog's Software Catalog
- Configures ownership (team-08-plugins), Slack contact, tier, and repo link
- Once merged to main, Datadog automatically picks up the service definition

## Test plan
- [ ] Verify the YAML is valid and matches the [v3 schema](https://github.com/DataDog/schema/tree/main/service-catalog/v3)
- [ ] After merge, confirm the service appears in Datadog Software Catalog

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a Datadog Software Catalog metadata file only; no runtime code paths or data handling are affected.
> 
> **Overview**
> Registers this repo as a Datadog Software Catalog service by adding `.github/service.datadog.yaml` with ownership, contact, tags, repo link, and lifecycle/tier metadata.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e8a656abbcc4f568f3fe68108eac7fd5394b9744. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->