### PR TITLE
Update Datadog service owner to team-08

### DIFF
--- a/.github/service.datadog.yaml
+++ b/.github/service.datadog.yaml
@@ -2,7 +2,7 @@ apiVersion: v3
 kind: service
 metadata:
   name: zonos-php-sdk
-  owner: team-08-plugins
+  owner: team-08
   description: >-
     PHP SDK for integrating with Zonos services, providing access
     to the Zonos GraphQL API.


### PR DESCRIPTION
## Summary
• Updates `owner` in `.github/service.datadog.yaml` from `team-08-plugins` to `team-08` to match the standardized Datadog team naming convention.

## Test plan
• Verify the service appears under the correct team in Datadog Service Catalog after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk metadata-only change affecting Datadog Service Catalog ownership/attribution, with no runtime or code behavior impact.
> 
> **Overview**
> Reassigns Datadog Service Catalog ownership for `zonos-php-sdk` by changing `metadata.owner` in `.github/service.datadog.yaml` from `team-08-plugins` to `team-08` to align with standardized team naming.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f4b164c755a0871dca920f8e872f947c9ed79ad8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->