### PR TITLE
[08PLUG-267] Add opt-in custom amount-path mapping for cart-level priced items

### DIFF
--- a/src/Config/ZonosConfig.php
+++ b/src/Config/ZonosConfig.php
@@ -19,6 +19,13 @@ class ZonosConfig
   private array $mappings = [];
 
   /**
+   * Free-form options keyed by name (e.g. 'amountPath').
+   *
+   * @var array<string, mixed>
+   */
+  private array $options = [];
+
+  /**
    * Create a new ZonosConfig instance
    *
    * @param array<string, mixed> $config Configuration settings
@@ -26,6 +33,7 @@ class ZonosConfig
   public function __construct(array $config = [])
   {
     $this->mappings = $config['mappings'] ?? [];
+    $this->options = $config['options'] ?? [];
   }
 
   /**
@@ -47,5 +55,17 @@ class ZonosConfig
   public function getMapping(string $entity): ?array
   {
     return $this->mappings[$entity] ?? null;
+  }
+
+  /**
+   * Get a top-level option value, with a default fallback.
+   *
+   * @param string $key Option key
+   * @param mixed $default Value to return if option is unset
+   * @return mixed
+   */
+  public function getOption(string $key, mixed $default = null): mixed
+  {
+    return $this->options[$key] ?? $default;
   }
 }

--- a/src/Services/DataMapperService.php
+++ b/src/Services/DataMapperService.php
@@ -232,6 +232,28 @@ class DataMapperService
 
   private function mapAmount(array $productData, string $value, array $cart_item): float
   {
+    // Opt-in: when amountPath is configured, resolve the per-item amount from
+    // the cart item directly. This covers cart-level pricing plugins (Gravity
+    // Forms, Name Your Price, Dynamic Pricing, Subscriptions, etc.) without
+    // changing behavior for merchants who haven't configured it.
+    $amountPath = (string) $this->config->getOption('amountPath', '');
+    if ($amountPath !== '') {
+      $resolved = $this->resolveCartItemPath($cart_item, $amountPath);
+      if (is_numeric($resolved)) {
+        $amount = (float) $resolved;
+        if ((bool) $this->config->getOption('amountPathIsPerLine', false)) {
+          $qty = max(1, (int) ($cart_item['quantity'] ?? 1));
+          return $amount / $qty;
+        }
+        return $amount;
+      }
+      $this->logger->sendLog(
+        "Zonos amountPath '{$amountPath}' did not resolve to a numeric value; falling back to mapping value '{$value}'",
+        LogType::ERROR
+      );
+      // intentional fall-through to existing mapping behavior
+    }
+
     $price = 0;
     switch ($value) {
       case 'plugin_wapf':
@@ -249,6 +271,53 @@ class DataMapperService
     }
 
     return (float)($productData[$value] ?? 0);
+  }
+
+  /**
+   * Walk a dot-separated path into a cart item to resolve a value. When a
+   * node is a WC_Data instance (WC_Product, WC_Product_Variation, etc.),
+   * auto-flatten via get_data() so paths like "data.price" reach the price
+   * set by set_price() at woocommerce_add_cart_item.
+   *
+   * @param array<string, mixed> $cart_item Cart item data
+   * @param string $path Dot-separated path
+   * @return mixed|null null if the path cannot be resolved
+   */
+  private function resolveCartItemPath(array $cart_item, string $path): mixed
+  {
+    $parts = explode('.', $path);
+    $node = $cart_item;
+    foreach ($parts as $part) {
+      if ($part === '') {
+        return null;
+      }
+      if (is_array($node)) {
+        if (!array_key_exists($part, $node)) {
+          return null;
+        }
+        $node = $node[$part];
+        continue;
+      }
+      if ($node instanceof \WC_Data) {
+        // Prefer the canonical getter so values written via set_<prop>()
+        // (which live in $changes, not $data) remain reachable.
+        // WC_Data::get_<prop>() delegates to get_prop(), which consults
+        // $changes before $data; get_data() returns $this->data only.
+        $getter = 'get_' . $part;
+        if (method_exists($node, $getter)) {
+          $node = $node->{$getter}();
+          continue;
+        }
+        $data = $node->get_data();
+        if (!array_key_exists($part, $data)) {
+          return null;
+        }
+        $node = $data[$part];
+        continue;
+      }
+      return null;
+    }
+    return $node;
   }
 
   /**


### PR DESCRIPTION
  ## Context                                                                                                                      
                                                                                                 
  Linear ticket:                                                                                                                  
  [08PLUG-267](https://linear.app/zonos/issue/08PLUG-267/wc-checkout-item-prices-passing-as-dollar000-cad-in-zonos-checkout)      
                                                                                                                                  
  GunfightersINC's WooCommerce store reports item prices arriving as $0.00 in the Zonos checkout widget. Root cause: the merchant 
  uses Gravity Forms Product Add-Ons, which intentionally sets the WooCommerce `_price` postmeta to $0 and stamps the actual price
   onto the cart item via `set_price()`. Today's `mapAmount` reads from the DB-hydrated product's postmeta, so it returns $0.     
                                                                                                                             
  This affects any plugin that drives pricing at the cart level (Gravity Forms, Name Your Price, Dynamic Pricing, Subscriptions,  
  etc.) — not just GunfightersINC.                                                                                              
                                                                                                                                  
  ## What this PR does                
                                                                                                                                  
  Adds an opt-in `amountPath` option to `ZonosConfig`. When set, `DataMapperService::mapAmount` resolves the per-item amount by   
  walking the configured dot-path through `$cart_item` (e.g. `data.price`, `_gform_total`, `line_subtotal`). When traversing into
  a `WC_Data` instance the resolver prefers the canonical getter method (`get_price()`, etc.) so values written via `set_price()` 
  (which live in `$changes`, not `$data`) are reachable.                                                                         
                                                                                                                                  
  Also adds an `amountPathIsPerLine` toggle that divides the resolved value by `cart_item['quantity']` for paths that resolve to a
   per-line total.                                                                                                                
                                                                                                                                  
  ## Behavior contract                
                                                                                                                                  
  - **`amountPath` empty** (existing merchants): byte-for-byte identical to v1.1.9. The new code is a no-op.
  - **`amountPath` set, resolves to numeric**: returns the resolved value (or `value / quantity` if per-line is on).              
  - **`amountPath` set, resolves to null/non-numeric**: logs to Datadog at ERROR level, falls back to existing dropdown behavior.
  Cart export does not crash.                                                                                                    
  - Existing `plugin_wapf` handler unchanged. WAPF merchants who haven't set `amountPath` keep their current behavior.            
                                                                                                                      
  ## Verification                                                                                                                 
                                                                                                 
  - 10/10 isolation tests passing (`test-sdk-isolation.php`, mocked `WC_Data`).
  - AJAX-level scenarios A/B/C verified against a local WP+WC install with a fake-Gravity-Forms mu-plugin.                        
  - End-to-end against the actual Zonos checkout modal (via ngrok-tunneled local site, GunfightersINC test credentials): backend
  cart quote shows GF Test Product = $159 USD, regular product = $25 USD — correct.                                               
                                                                                                                                  
  ## Coordination                                                                                                                 
                                                                                                                                  
  Plugin PR with the matching admin field + SDK config payload: [Zonos/woocommerce-checkout PR](https://github.com/Zonos/woocommerce-checkout/pull/98).    
  Plugin's composer pin needs to bump from `1.1.9` to `1.1.10` after this SDK PR ships and the v1.1.10 tag is cut. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches price mapping in `DataMapperService::mapAmount`, so misconfiguration could change amounts sent to Zonos; behavior is opt-in with fallback to existing logic when unset or invalid.
> 
> **Overview**
> Adds support for **opt-in amount resolution from WooCommerce cart items** to handle cart-level pricing plugins that don’t store the final price in product meta.
> 
> `ZonosConfig` now accepts a top-level `options` bag and exposes `getOption()`. `DataMapperService::mapAmount` can use an `amountPath` (dot path into `$cart_item`, with WC `WC_Data` getter support) and optional `amountPathIsPerLine` quantity normalization; non-numeric/invalid paths log an error and fall back to the prior mapping behavior (including the existing `plugin_wapf` handling).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9015f4ca972217d583ae9bb1d105f8899d91da9b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->