### PR TITLE
Add 'addon_fields' attribute type for universal add-on plugin import …

### DIFF
--- a/src/Services/DataMapperService.php
+++ b/src/Services/DataMapperService.php
@@ -162,6 +162,33 @@ class DataMapperService
               $value = (string)$value;
             }
             break;
+          case 'addon_fields':
+            // Opt-in: pull the cart line's display fields straight from
+            // WooCommerce's standard woocommerce_get_item_data filter — the
+            // same source the native cart/order view uses. Any add-on plugin
+            // (Gravity Forms, WAPF, YITH, etc.) that registers display data is
+            // surfaced with its real labels, already product-specific and free
+            // of the field-id collisions that raw _gravity_form_lead lookups hit.
+            $itemData = apply_filters('woocommerce_get_item_data', [], $cart_item);
+            foreach ((array)$itemData as $row) {
+              if (!is_array($row)) {
+                continue;
+              }
+              // WC core uses 'key'/'display'; some add-ons use 'name'/'value'.
+              $label = trim(wp_strip_all_tags((string)($row['key'] ?? $row['name'] ?? '')));
+              $cleanValue = trim(wp_strip_all_tags((string)($row['display'] ?? $row['value'] ?? '')));
+              if ($label !== '' && $cleanValue !== '') {
+                // 'Alias: ' prefix is required: on import, WordpressService
+                // strips it and uses the remainder as the order-item meta key
+                // (i.e. the field label), matching the 'custom' alias path.
+                $productAttributes[] = [
+                  'key' => 'Alias: ' . $label,
+                  'value' => $cleanValue,
+                ];
+              }
+            }
+            // $value stays null so the single-append tail below is skipped.
+            break;
         }
 
         if ($value) {
@@ -175,7 +202,11 @@ class DataMapperService
             'value' => $value,
           ];
         }
-      } catch (\Exception $e) {
+      } catch (\Throwable $e) {
+        // \Throwable (not just \Exception): the addon_fields case runs
+        // arbitrary third-party hook code via woocommerce_get_item_data, which
+        // can throw \Error/\TypeError. Contain it per-row so one bad add-on
+        // plugin can't abort the whole cart export.
         $this->logger->sendLog('Error mapping attribute ' . $attribute, LogType::ERROR);
       }
     }


### PR DESCRIPTION
…(08PLUG-313)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Runs arbitrary third-party filter code during cart export; failures are isolated per attribute but exported data now depends on add-on plugin behavior.
> 
> **Overview**
> Adds an opt-in **`addon_fields`** product attribute mapping type so cart export can include add-on display data from WooCommerce’s **`woocommerce_get_item_data`** filter (same source as cart/checkout), instead of brittle per-plugin meta paths.
> 
> For each non-empty label/value pair, rows are emitted as **`Alias: {label}`** attributes so import via **`WordpressService`** can restore order-item meta by field label, consistent with the existing custom alias path. Attribute mapping errors are caught as **`\Throwable`** so a failing third-party add-on hook cannot abort the whole cart export.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ebe3110e3a62a00c04527683cc06fcbb497578e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->