### PR TITLE
Price cart items from the cart line to capture bundle/dynamic discounts

### DIFF
--- a/src/Services/DataMapperService.php
+++ b/src/Services/DataMapperService.php
@@ -299,6 +299,24 @@ class DataMapperService
         }
 
         return $price + (float)($productData['price'] ?? 0);
+      case 'price':
+        // Derive the per-unit amount from the cart line rather than the
+        // catalog price so cart-level price modifications (product bundles,
+        // dynamic pricing, role-based pricing, etc.) are reflected. Without
+        // this, bundled/discounted items export at their standalone catalog
+        // price and the checkout total exceeds the cart total.
+        //
+        // line_subtotal is the pre-tax, pre-coupon line total; coupons are
+        // exported separately as cart adjustments, so this must remain
+        // pre-coupon to avoid double-counting. Fall back to the catalog price
+        // when the line subtotal is unavailable (e.g. totals not yet
+        // calculated).
+        $lineSubtotal = $cart_item['line_subtotal'] ?? null;
+        $quantity = (int)($cart_item['quantity'] ?? 0);
+        if (is_numeric($lineSubtotal) && $quantity > 0) {
+          return (float)$lineSubtotal / $quantity;
+        }
+        return (float)($productData['price'] ?? 0);
     }
 
     return (float)($productData[$value] ?? 0);

--- a/src/ZonosSdk.php
+++ b/src/ZonosSdk.php
@@ -2,7 +2,7 @@
 
 namespace Zonos\ZonosSdk;
 
-define('VERSION', '1.1.10');
+define('VERSION', '1.1.12');
 
 use InvalidArgumentException;
 use Zonos\ZonosSdk\Config\ZonosConfig;


### PR DESCRIPTION
## Problem

Bundled/discounted items export to Zonos at their **standalone catalog price**, so the Zonos checkout total exceeds the WooCommerce cart total.

Real-world case (WooCommerce Product Bundles):
- Cart shows the bundle at **CA\$588.47** (bundle discount applied on the cart line)
- Zonos checkout showed **CA\$648.83** — the raw catalog prices summed: `445.13 + 60.36 + 30.18 + 113.17`
- The ~CA\$60 bundle discount was silently dropped

## Root cause

`DataMapperService::mapAmount()` resolved the default `'price'` mapping from `$product->get_data()['price']` — the product's **catalog** price. Cart-level price modifications (Product Bundles, dynamic pricing, role-based pricing, etc.) live on the **cart line**, not the catalog record, so they were never reflected.

Coupons were already handled separately as cart adjustments (`WordPressService::getDiscountApplied`), but bundle discounts are not coupons and had no path into the export.

## Fix

The `'price'` case now derives the per-unit amount from the cart line:

```php
$lineSubtotal / $quantity
```

- `line_subtotal` already reflects cart-level price adjustments.
- It is **pre-coupon**, so coupons continue to flow through as separate cart adjustments with no double-counting.
- Falls back to the catalog price when `line_subtotal` is unavailable (e.g. totals not yet calculated).

Only the default `'price'` mapping changes. The `plugin_wapf` branch, the opt-in `amountPath` override, and any custom mapping value are untouched — merchants who set `amountPath` still hit that path first.

## Versioning

Bumps `VERSION` `1.1.10` → `1.1.12`. `v1.1.11` is the latest released tag (the plugin currently pins it), so the next release is `v1.1.12`. `main` and `v1.1.11` were functionally identical apart from the `VERSION` constant, so `main` is the correct base.

## Follow-up (not in this PR)

After merge + tag `v1.1.12`, the WooCommerce plugin's `composer.json`/`composer.lock` need bumping to `v1.1.12` to consume the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes checkout amount calculation for all default price mappings; incorrect line_subtotal handling could misstate totals, though fallback to catalog price limits exposure.
> 
> **Overview**
> Fixes Zonos checkout totals exceeding the WooCommerce cart when **cart-level discounts** (e.g. Product Bundles) apply but export still used **catalog** prices.
> 
> For the default `'price'` amount mapping, **`DataMapperService::mapAmount()`** now returns **`line_subtotal / quantity`** from the cart line so bundle/dynamic/role pricing on the line is included. It stays **pre-coupon** (coupons remain separate adjustments); if `line_subtotal` or quantity is missing, behavior falls back to **`$productData['price']`**. **`amountPath`**, **`plugin_wapf`**, and other mapping values are unchanged.
> 
> SDK **`VERSION`** is bumped **1.1.10 → 1.1.12**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f6f9d69fd523f3cdbbcd2cd84b0596818430afe9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->