### PR TITLE
Restore development VERSION so release automation owns the bump

### DIFF
--- a/src/ZonosSdk.php
+++ b/src/ZonosSdk.php
@@ -2,7 +2,7 @@
 
 namespace Zonos\ZonosSdk;
 
-define('VERSION', '1.1.12');
+define('VERSION', '1.1.10');
 
 use InvalidArgumentException;
 use Zonos\ZonosSdk\Config\ZonosConfig;


### PR DESCRIPTION
## Why

The release build failed on the `update-version-v1.1.12` branch:

```
Run git add src/ZonosSdk.php
On branch update-version-v1.1.12
nothing to commit, working tree clean
Error: Process completed with exit code 1.
```

PR #62 hardcoded `VERSION` to `1.1.12`. The release automation sets `VERSION` itself and then commits — but since the value already matches, there's nothing to commit and the job exits 1.

## Fix

Revert the `VERSION` constant to the pre-#62 development value (`1.1.10`). The `update-version-vX` job then produces a real diff (`1.1.10` → `1.1.12`), commits, and tags as normal.

The functional cart-line pricing fix from #62 is untouched — only the version constant changes here.

## After merge

Re-run the release automation to cut `v1.1.12`.

Refs 08PLUG-356.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single constant change for release plumbing; only operational impact is the reported SDK version in client headers until release runs again.
> 
> **Overview**
> **Reverts the hardcoded SDK version** in `src/ZonosSdk.php` from `1.1.12` back to the development baseline `1.1.10`.
> 
> Release workflow uses `sed` to set `VERSION` and then commits that change. When main already had `1.1.12` from PR #62, the automation produced no diff and the commit step failed with a clean working tree.
> 
> After merge, re-running release should create a real `1.1.10` → `1.1.12` commit, tag, and PR as usual. Until the next release cut, `x-client-version` will report the older SDK segment `(sdk:1.1.10)` even if other fixes from #62 remain on main.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da878f4b13fbe0914c0f4175e9b80856ade013d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->