### PR TITLE
Update version to v1.1.12

### DIFF
--- a/src/ZonosSdk.php
+++ b/src/ZonosSdk.php
@@ -2,7 +2,7 @@
 
 namespace Zonos\ZonosSdk;
 
-define('VERSION', '1.1.10');
+define('VERSION', '1.1.12');
 
 use InvalidArgumentException;
 use Zonos\ZonosSdk\Config\ZonosConfig;


### PR DESCRIPTION
Reconciles `main` with the already-published `v1.1.12` release. `main` still declares `VERSION 1.1.10` while `v1.1.11` and `v1.1.12` are published tags and releases.

This bump commit was created by the release workflow on 2026-07-01 and pushed, but the PR was never opened — `secrets.ACTION_SECRET` is a PAT owned by a consultant offboarded on 2026-05-22, so `gh pr create` failed with `must be a collaborator`. The commit has sat on this branch ever since. Run `28544507526`.

No new code here: this is the original workflow-generated commit, 1 ahead of `main`, 0 behind, touching only `src/ZonosSdk.php`.

**Please merge with a merge commit rather than squash.** Tag `v1.1.12` points at this exact commit (`9ea5715`); a merge keeps the tag an ancestor of `main`, a squash would leave it orphaned again.

Tag `v1.1.12` stays as-is either way — `woocommerce-checkout` pins `zonos/zonos-php-sdk: 1.1.12` with `reference: v1.1.12` in its composer.json.

Why it matters: anyone consuming the SDK off `main` gets code that self-reports `1.1.10`, two releases behind what is actually published. This is cleanup, not a blocker — the new release workflow reads the version from `src/ZonosSdk.php` and no-ops when a matching tag exists, and `v1.1.10` is tagged, so it would sit quiet either way.

DEV-1427

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single constant bump with no logic changes; only affects the reported SDK version string in client headers.
> 
> **Overview**
> Updates the `VERSION` constant in `src/ZonosSdk.php` from **`1.1.10`** to **`1.1.12`** so `main` matches the already-published **`v1.1.12`** tag and release.
> 
> That constant is embedded in the **`x-client-version`** header as `sdk:VERSION`, so consumers on `main` will report the correct SDK version instead of lagging two releases behind what Composer/tags already ship.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ea5715799b4b16bd453222bb3ad56d31da717ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->