### PR TITLE
ci: two-phase release workflow, drop dead PAT (DEV-1427)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,8 @@
 name: Release
 
+# Opens the version-bump PR. Tagging happens in tag-and-release.yml after the
+# PR merges, so the tag always points at a commit on the base branch.
+
 on:
   workflow_dispatch:
     inputs:
@@ -7,6 +10,11 @@ on:
         description: "Version to release, vX.Y.Z"
         required: true
         type: string
+      base_branch:
+        description: "Branch to release from"
+        required: false
+        type: string
+        default: main
       dry_run:
         description: "Show the diff without pushing"
         required: false
@@ -23,12 +31,95 @@ concurrency:
 
 jobs:
   version-pr:
-    uses: Zonos/github-actions/.github/workflows/php-plugin-version-pr.yml@v1
-    with:
-      version: ${{ inputs.version }}
-      dry_run: ${{ inputs.dry_run }}
-      version_constant: VERSION
-      version_files: src/ZonosSdk.php
-      use_app_token: true
-    secrets:
-      app_private_key: ${{ secrets.TF_VAR_GITHUB_APP_PRIVATE_KEY }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.RELEASE_APP_ID }}
+          private-key: ${{ secrets.TF_VAR_GITHUB_APP_PRIVATE_KEY }}
+
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.base_branch }}
+          fetch-depth: 0
+          fetch-tags: true
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Validate inputs
+        env:
+          VERSION: ${{ inputs.version }}
+          BASE_BRANCH: ${{ inputs.base_branch }}
+        run: |
+          set -euo pipefail
+          if [[ ! "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::version must match vX.Y.Z (got '$VERSION')"
+            exit 1
+          fi
+          if [[ ! "$BASE_BRANCH" =~ ^[A-Za-z0-9._/-]+$ ]]; then
+            echo "::error::invalid base_branch '$BASE_BRANCH'"
+            exit 1
+          fi
+          if git rev-parse -q --verify "refs/tags/$VERSION" >/dev/null; then
+            echo "::error::tag $VERSION already exists"
+            exit 1
+          fi
+          if git ls-remote --exit-code --heads origin "update-version-$VERSION" >/dev/null 2>&1; then
+            echo "::error::branch update-version-$VERSION already exists on origin. Delete it and re-run."
+            exit 1
+          fi
+          {
+            echo "VERSION=$VERSION"
+            echo "VERSION_NUMBER=${VERSION#v}"
+            echo "TEMP_BRANCH=update-version-$VERSION"
+          } >> "$GITHUB_ENV"
+
+      - name: Bump version
+        run: |
+          set -euo pipefail
+          sed -i -E "s/define\('VERSION', *'[0-9]+\.[0-9]+\.[0-9]+'\)/define('VERSION', '${VERSION_NUMBER}')/" src/ZonosSdk.php
+          # Confirm the edit landed: a silently unmatched pattern would ship a
+          # release whose source still declares the old version.
+          grep -qF "define('VERSION', '${VERSION_NUMBER}')" src/ZonosSdk.php || {
+            echo "::error::src/ZonosSdk.php does not declare VERSION ${VERSION_NUMBER}. Expected a line matching: define('VERSION', 'X.Y.Z')"
+            exit 1
+          }
+
+      - name: Verify there is something to commit
+        env:
+          BASE_BRANCH: ${{ inputs.base_branch }}
+        run: |
+          set -euo pipefail
+          if git diff --quiet; then
+            echo "::error::nothing to commit — the tree already declares ${VERSION_NUMBER}. Pick a higher version, or the bump is already on ${BASE_BRANCH}."
+            exit 1
+          fi
+
+      - name: Show dry run summary
+        if: inputs.dry_run
+        run: |
+          echo "=== DRY RUN — nothing will be pushed ==="
+          echo "Version: ${VERSION}"
+          echo "Branch that would be created: ${TEMP_BRANCH}"
+          echo ""
+          git --no-pager diff
+
+      - name: Commit and open PR
+        if: ${{ !inputs.dry_run }}
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          BASE_BRANCH: ${{ inputs.base_branch }}
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$TEMP_BRANCH"
+          git commit -am "chore: update version to ${VERSION}"
+          git push origin "$TEMP_BRANCH"
+          gh pr create \
+            --base "$BASE_BRANCH" \
+            --head "$TEMP_BRANCH" \
+            --title "Update version to ${VERSION}" \
+            --body "Automated version bump to ${VERSION}. Merging this PR triggers the tag and GitHub release."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.RELEASE_APP_ID }}
+          app-id: 2749186
           private-key: ${{ secrets.TF_VAR_GITHUB_APP_PRIVATE_KEY }}
 
       - name: Checkout repository

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,5 +29,6 @@ jobs:
       dry_run: ${{ inputs.dry_run }}
       version_constant: VERSION
       version_files: src/ZonosSdk.php
+      use_app_token: true
     secrets:
       app_private_key: ${{ secrets.TF_VAR_GITHUB_APP_PRIVATE_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,75 +1,33 @@
-name: Build SDK
+name: Release
 
 on:
   workflow_dispatch:
     inputs:
-      tag_version:
-        description: 'Version tag to create (e.g., v1.2.3)'
+      version:
+        description: "Version to release, vX.Y.Z"
         required: true
-      branch:
-        description: 'Branch to create tag from'
-        required: true
-        default: 'main'
+        type: string
+      dry_run:
+        description: "Show the diff without pushing"
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+  pull-requests: write
 
 concurrency:
-  group: build-and-release
+  group: release-${{ github.repository }}
   cancel-in-progress: false
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.branch }}
-          fetch-depth: 0
-
-      - name: Extract version from input
-        run: echo "VERSION=${{ inputs.tag_version }}" >> $GITHUB_ENV
-
-      - name: Create temporary branch for version update
-        run: |
-          git config --global user.name "github-actions"
-          git config --global user.email "github-actions@github.com"
-          TEMP_BRANCH="update-version-${VERSION}"
-          git checkout -b "$TEMP_BRANCH"
-          echo "TEMP_BRANCH=${TEMP_BRANCH}" >> $GITHUB_ENV
-
-      - name: Update version in SDK file
-        run: |
-          sed -i "s/define('VERSION', '[0-9]\+\.[0-9]\+\.[0-9]\+');/define('VERSION', '${VERSION#v}');/" src/ZonosSdk.php
-
-      - name: Commit and push version change
-        run: |
-          git add src/ZonosSdk.php
-          git commit -m "Update version to ${VERSION}"
-          git push origin "$TEMP_BRANCH"
-        env:
-          GITHUB_TOKEN: ${{ secrets.ACTION_SECRET }}
-
-      - name: Create tag on latest commit
-        run: |
-          git tag "${VERSION}"
-          git push origin "${VERSION}"
-        env:
-          GITHUB_TOKEN: ${{ secrets.ACTION_SECRET }}
-
-      - name: Create Pull Request
-        run: |
-          gh pr create \
-            --base "${{ inputs.branch }}" \
-            --head "$TEMP_BRANCH" \
-            --title "Update version to ${VERSION}" \
-            --body "This PR updates the version to ${VERSION}."
-        env:
-          GITHUB_TOKEN: ${{ secrets.ACTION_SECRET }}
-
-      - name: Create GitHub release
-        run: |
-          gh release create "${VERSION}" \
-            --title "Release ${VERSION}" \
-            --generate-notes
-        env:
-          GITHUB_TOKEN: ${{ secrets.ACTION_SECRET }}
+  version-pr:
+    uses: Zonos/github-actions/.github/workflows/php-plugin-version-pr.yml@v1
+    with:
+      version: ${{ inputs.version }}
+      dry_run: ${{ inputs.dry_run }}
+      version_constant: VERSION
+      version_files: src/ZonosSdk.php
+    secrets:
+      app_private_key: ${{ secrets.TF_VAR_GITHUB_APP_PRIVATE_KEY }}

--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -22,7 +22,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.RELEASE_APP_ID }}
+          app-id: 2749186
           private-key: ${{ secrets.TF_VAR_GITHUB_APP_PRIVATE_KEY }}
 
       - name: Checkout repository

--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -1,7 +1,7 @@
 name: Tag and Release
 
-# No-ops unless src/ZonosSdk.php declares an untagged version, so the tag
-# always lands on main — the DEV-1427 drift that stranded v1.1.11/v1.1.12.
+# Runs on every push to main and exits unless src/ZonosSdk.php declares a
+# version that has no tag yet, so only a version bump produces a release.
 
 on:
   push:
@@ -10,12 +10,73 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  group: tag-and-release-${{ github.repository }}
+  cancel-in-progress: false
+
 jobs:
   release:
-    uses: Zonos/github-actions/.github/workflows/php-plugin-release.yml@v1
-    with:
-      version_constant: VERSION
-      version_file: src/ZonosSdk.php
-      use_app_token: true
-    secrets:
-      app_private_key: ${{ secrets.TF_VAR_GITHUB_APP_PRIVATE_KEY }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.RELEASE_APP_ID }}
+          private-key: ${{ secrets.TF_VAR_GITHUB_APP_PRIVATE_KEY }}
+
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Determine whether a release is due
+        id: check
+        run: |
+          set -euo pipefail
+          # `|| true` is load-bearing: under pipefail a no-match grep kills the
+          # step here, so the error below would never print.
+          VERSION_NUMBER=$(grep -oE "define\('VERSION', *'[0-9]+\.[0-9]+\.[0-9]+'\)" src/ZonosSdk.php \
+            | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -n1 || true)
+          if [ -z "$VERSION_NUMBER" ]; then
+            echo "::error::could not read VERSION from src/ZonosSdk.php"
+            exit 1
+          fi
+          VERSION="v${VERSION_NUMBER}"
+          if git rev-parse -q --verify "refs/tags/${VERSION}" >/dev/null; then
+            echo "Tag ${VERSION} already exists. Nothing to release."
+            echo "due=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "due=true" >> "$GITHUB_OUTPUT"
+          echo "VERSION=$VERSION" >> "$GITHUB_ENV"
+
+      - name: Build release notes
+        if: steps.check.outputs.due == 'true'
+        run: |
+          set -euo pipefail
+          # Highest semver tag, not newest by commit date, and no hard-fail
+          # when the repo has no tags yet.
+          PREV_TAG=$(git tag -l 'v*' --sort=-v:refname | head -n1)
+          if [ -n "$PREV_TAG" ]; then RANGE="${PREV_TAG}..HEAD"; else RANGE="HEAD"; fi
+          {
+            echo "## Release Notes"
+            echo ""
+            git log --pretty=format:'- %s (%h)' "$RANGE"
+            echo ""
+          } > release_notes.txt
+          cat release_notes.txt
+
+      - name: Create tag and release
+        if: steps.check.outputs.due == 'true'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag "$VERSION"
+          git push origin "$VERSION"
+          gh release create "$VERSION" --title "Release $VERSION" --notes-file release_notes.txt

--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -64,7 +64,9 @@ jobs:
           {
             echo "## Release Notes"
             echo ""
-            git log --pretty=format:'- %s (%h)' "$RANGE"
+            # Squash-merge names the bump commit from the PR title, so match any
+            # casing or prefix rather than just the one we author.
+            git log --pretty=format:'- %s (%h)' --invert-grep -i --grep='update version to v' "$RANGE"
             echo ""
           } > release_notes.txt
           cat release_notes.txt

--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -19,5 +19,6 @@ jobs:
     with:
       version_constant: VERSION
       version_file: src/ZonosSdk.php
+      use_app_token: true
     secrets:
       app_private_key: ${{ secrets.TF_VAR_GITHUB_APP_PRIVATE_KEY }}

--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -1,0 +1,23 @@
+name: Tag and Release
+
+# Fires on every push to main and no-ops unless src/ZonosSdk.php declares a
+# version with no matching tag. The tag therefore always lands on a commit
+# that is actually on main — the old workflow tagged the temp branch before
+# its PR merged, which is why v1.1.11 and v1.1.12 shipped while main still
+# said 1.1.10 (DEV-1427).
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    uses: Zonos/github-actions/.github/workflows/php-plugin-release.yml@v1
+    with:
+      version_constant: VERSION
+      version_file: src/ZonosSdk.php
+    secrets:
+      app_private_key: ${{ secrets.TF_VAR_GITHUB_APP_PRIVATE_KEY }}

--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -1,10 +1,7 @@
 name: Tag and Release
 
-# Fires on every push to main and no-ops unless src/ZonosSdk.php declares a
-# version with no matching tag. The tag therefore always lands on a commit
-# that is actually on main — the old workflow tagged the temp branch before
-# its PR merged, which is why v1.1.11 and v1.1.12 shipped while main still
-# said 1.1.10 (DEV-1427).
+# No-ops unless src/ZonosSdk.php declares an untagged version, so the tag
+# always lands on main — the DEV-1427 drift that stranded v1.1.11/v1.1.12.
 
 on:
   push:

--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -61,12 +61,14 @@ jobs:
           # when the repo has no tags yet.
           PREV_TAG=$(git tag -l 'v*' --sort=-v:refname | head -n1)
           if [ -n "$PREV_TAG" ]; then RANGE="${PREV_TAG}..HEAD"; else RANGE="HEAD"; fi
+          NOTES=$(git log --pretty=format:'- %s (%h)' --invert-grep -i --grep='update version to v' "$RANGE")
+          # An all-bump range filters to nothing; avoid a release body that is
+          # just a bare header.
+          [ -n "$NOTES" ] || NOTES='- Maintenance release; no functional changes.'
           {
             echo "## Release Notes"
             echo ""
-            # Squash-merge names the bump commit from the PR title, so match any
-            # casing or prefix rather than just the one we author.
-            git log --pretty=format:'- %s (%h)' --invert-grep -i --grep='update version to v' "$RANGE"
+            echo "$NOTES"
             echo ""
           } > release_notes.txt
           cat release_notes.txt


### PR DESCRIPTION
Replaces this repo's release workflow with a two-phase design and moves auth off `secrets.ACTION_SECRET` onto a GitHub App installation token.

## Why these are inline rather than shared

The other plugin repos call shared reusable workflows from `Zonos/github-actions`. This repo cannot: that repo is private, and [GitHub does not allow a public repository to consume reusable workflows from a private one](https://docs.github.com/en/actions/how-tos/reuse-automations/share-with-your-organization) regardless of the organization access setting. Keeping this repo public is deliberate, so the two workflows are inlined here.

They are purpose-built rather than a copy of the generic pair — no Composer, no zip, no plugin header or readme handling — which is why they come to 207 lines instead of ~400.

## What changes

- `release.yml` (`workflow_dispatch`) bumps `src/ZonosSdk.php` and opens the version PR. It no longer tags.
- New `tag-and-release.yml` (`push: main`) reads the version out of `src/ZonosSdk.php`, exits if that tag exists, otherwise tags the merged commit and cuts the release.

Splitting the two is what fixes the version drift: the previous workflow tagged the temp-branch commit before its PR merged, which is why `v1.1.11` and `v1.1.12` are published while `main` still declares `1.1.10`. Tagging after the merge means the tag always points at a commit on the base branch.

## Public-repo review notes

Workflow files in a public repo are public. These were audited on that basis:

- No credentials in source. The key comes from `secrets.TF_VAR_GITHUB_APP_PRIVATE_KEY`. The App ID is hardcoded on purpose: it is not a secret (`GET /apps/zonos-checkout` returns it to any authenticated user), it is immutable for the App's lifetime, and a variable would not hide it anyway since a step's `with:` inputs are printed into this repo's public run logs. Hardcoding matches the other Zonos release workflows and removes a setup step that would silently break both workflows if missed.
- No `${{ }}` interpolation inside any `run:` body; every dynamic value arrives through `env:`, so there is no script-injection surface.
- Triggers are `workflow_dispatch` and `push: main` only. Neither can be fired from a fork.
- Least-privilege `permissions:` per workflow — `contents: write` for the tag job, plus `pull-requests: write` for the PR job.
- Only first-party actions (`actions/checkout@v6`, `actions/create-github-app-token@v3`). No third-party action has access to the job environment.
- Comments describe mechanics only. No ticket references, internal hostnames, account identifiers, or incident detail.

## Also picked up

`checkout@v6`, `github-actions[bot]` identity, a `dry_run` input, a `base_branch` input, input validation with guards for an existing tag or leftover branch, verification that the version edit actually matched, and a previous-tag lookup that sorts by semver rather than commit date.

## Before merging

- Validated with `dry_run: true` against this branch.
- First real bump must be **≥ v1.1.13**; `v1.1.11` and `v1.1.12` exist and the workflow hard-fails on an existing tag.
- [#64](https://github.com/Zonos/zonos-php-sdk/pull/64) reconciles `main` to 1.1.12 and is independent.

DEV-1427

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how production tags and GitHub releases are cut and which credentials can push tags/PRs; mistakes could block releases or tag the wrong commit until validated on main.
> 
> **Overview**
> **Replaces the single-step release flow** with a two-phase design so tags are created only after the version bump lands on the base branch, fixing drift where releases pointed at pre-merge commits while `main` still declared an older SDK version.
> 
> The **`release.yml`** `workflow_dispatch` job now only bumps `VERSION` in `src/ZonosSdk.php`, validates inputs (semver, no duplicate tag/branch), optionally **`dry_run`**, verifies the sed bump and a non-empty diff, then opens a PR—**it no longer tags or creates GitHub releases**. A new **`tag-and-release.yml`** runs on **`push` to `main`**, reads the version from `src/ZonosSdk.php`, skips if the tag already exists, otherwise builds semver-scoped release notes and pushes the tag plus `gh release create`.
> 
> **Auth moves** from `secrets.ACTION_SECRET` to a **GitHub App installation token** (`create-github-app-token@v3`), with scoped `permissions`, `checkout@v6`, and dynamic values passed via `env:` rather than interpolated into shell scripts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a8cd525be9aa02d5347968248846fb9b90fd805b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

