### PR TITLE
ci: reject a base_branch tag-and-release never watches (DEV-1427)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,6 +52,7 @@ jobs:
         env:
           VERSION: ${{ inputs.version }}
           BASE_BRANCH: ${{ inputs.base_branch }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
         run: |
           set -euo pipefail
           if [[ ! "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
@@ -60,6 +61,13 @@ jobs:
           fi
           if [[ ! "$BASE_BRANCH" =~ ^[A-Za-z0-9._/-]+$ ]]; then
             echo "::error::invalid base_branch '$BASE_BRANCH'"
+            exit 1
+          fi
+          # tag-and-release.yml only watches the default branch, so a bump merged
+          # elsewhere would never tag. Fail here rather than silently not releasing.
+          # Skipped if the context is unavailable, so it can never wrongly block.
+          if [ -n "${DEFAULT_BRANCH:-}" ] && [ "$BASE_BRANCH" != "$DEFAULT_BRANCH" ]; then
+            echo "::error::base_branch must be '$DEFAULT_BRANCH' (got '$BASE_BRANCH'). Releases only run from the default branch."
             exit 1
           fi
           if git rev-parse -q --verify "refs/tags/$VERSION" >/dev/null; then


### PR DESCRIPTION
Bugbot finding on #65, fixed as a follow-up rather than re-opening that PR for re-approval.

`release.yml` accepted a `base_branch` and opened the version PR against it, but `tag-and-release.yml` only triggers on `push` to the default branch. A bump merged into any other base would merge cleanly and never tag — while the PR body claims merging triggers the release. Silent partial success, the same failure shape DEV-1427 exists to remove.

Now rejected up front with the reason:

```
::error::base_branch must be 'main' (got 'release-0.6.0-beta'). Releases only run from the default branch.
```

Validate rather than support, since `tag-and-release.yml` watches one branch by design. The check is skipped when `github.event.repository.default_branch` is unavailable, so it can never wrongly block a release.

`woocommerce-checkout` gets the same fix via the shared workflow in Zonos/github-actions#403. This repo runs inlined copies, hence the separate change.

The `release-*` branches in this repo are dead experiments, confirmed — nothing needs releasing off a non-default branch.

DEV-1427

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only guardrail on manual release dispatch; no runtime or application code changes.
> 
> **Overview**
> The **Release** workflow’s `Validate inputs` step now requires `base_branch` to match the repo **default branch** (from `github.event.repository.default_branch`), because **`tag-and-release.yml` only runs on pushes to that branch** (e.g. `main`). A version bump merged elsewhere would succeed without ever tagging, while the PR still claims merging triggers the release.
> 
> If `base_branch` differs and the default branch name is known, the job fails with a clear `::error::` message. The check is **skipped when `DEFAULT_BRANCH` is empty**, so missing context cannot block a release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f80000179f10fc3f10578dbc3f9d47382cdcc51b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->